### PR TITLE
.netcore 版本中  Update DAService.cs 文件中OnValueChanged 函数中@startTime重复的修正

### DIFF
--- a/SCADA/Program/CoreApp/DataService/GateWay/DAService.cs
+++ b/SCADA/Program/CoreApp/DataService/GateWay/DAService.cs
@@ -1224,7 +1224,7 @@ namespace BatchCoreService
             DataHelper.Instance.ExecuteStoredProcedure("AddEventLog",
                 DataHelper.CreateParam("@StartTime", SqlDbType.DateTime, tag.TimeStamp),
                 DataHelper.CreateParam("@Source", SqlDbType.NVarChar, tag.ID.ToString(), 50),
-                DataHelper.CreateParam("@StartTime", SqlDbType.NVarChar, tag.ToString(), 50));
+                DataHelper.CreateParam("@Comment", SqlDbType.NVarChar, tag.ToString(), 50));
         }
 
         public HistoryData[] BatchRead(DataSource source, bool sync, params ITag[] itemArray)


### PR DESCRIPTION
void OnValueChanged(object sender, ValueChangedEventArgs e)函数中建立了两个@startTime 参数，第二个为重复信息。我与mysql数据库中存储过程AddEventLog进行了对比，发现其实际还需要@Comment的参数。此段代码与非.netcore的代码进行了对比，确实需要修改第二个重复的参数。